### PR TITLE
Correct the behaviour of `configure.sh` when $others expands to an expression containing whitespace

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,1 @@
+Andrew V. Jones, Vector Informatik

--- a/configure.sh
+++ b/configure.sh
@@ -235,7 +235,7 @@ fi
 [ $static = yes ] && CFLAGS="$CFLAGS -static"
 [ $profile = yes ] && CFLAGS="$CFLAGS -pg"
 [ $coverage = yes ] && CFLAGS="$CFLAGS -ftest-coverage -fprofile-arcs"
-[ $other = none ] || CFLAGS="$CFLAGS $other"
+[ "${other}" = none ] || CFLAGS="$CFLAGS ${other}"
 [ $log = no ] && CFLAGS="$CFLAGS -DNLGLOG"
 [ $check = no ] && CFLAGS="$CFLAGS -DNDEBUG"
 [ $chksol = no ] && CFLAGS="$CFLAGS -DNCHKSOL"


### PR DESCRIPTION
In some instances, it has been observed that $others can expand to a string containing white space, this means that the check against $others results in an error.

This PR modifies the syntax in configure.sh to avoid this issue.

Minor: it also introduces a CONTRIBUTORS file.