### PR TITLE
Avoid conflict between clone in sched.h and the Lingeling variables "clone" at global scope

### DIFF
--- a/blimc.c
+++ b/blimc.c
@@ -21,7 +21,7 @@ static unsigned num_bad;
 static aiger_symbol * badsyms;
 static FILE *outfile, *msgfile, *errfile, *apitrace;
 static int verbose, xstim, plain, nowitness, noclone;
-static LGL * lgl, * clone;
+static LGL * lgl, * lclone;
 static int * coi, opt = 3;
 static int cloned;
 
@@ -69,7 +69,7 @@ static void caughtsigmsg (int sig) {
 
 static void stats (void) {
   if (verbose) {
-    if (clone) lglstats (clone);
+    if (lclone) lglstats (lclone);
     if (lgl) lglstats (lgl);
   }
   msg (1, "reached k = %d", k);
@@ -592,25 +592,25 @@ int main (int argc, char ** argv) {
       if (!noclone) lglsetopt (lgl, "clim", 1000);
       res = lglsat (lgl);
       if (!res) {
-	assert (!clone);
+	assert (!lclone);
 	assert (!noclone);
-	clone = lglclone (lgl);
+	lclone = lglclone (lgl);
 	sprintf (prefix, "c [lgl%dclone%d] ", k, cloned++);
-	lglsetprefix (clone, prefix);
-	lglfixate (clone);
-	lglmeltall (clone);
+	lglsetprefix (lclone, prefix);
+	lglfixate (lclone);
+	lglmeltall (lclone);
 #if 0
 	if (cloned & (cloned-1)) res = 0;
 	else 
 #endif
-	  res = lglsimp (clone, 1);
+	  res = lglsimp (lclone, 1);
 	if (!res) {
-	  lglsetopt (clone, "clim", -1);
-	  res = lglsat (clone);
+	  lglsetopt (lclone, "clim", -1);
+	  res = lglsat (lclone);
 	  assert (res == 10 || res == 20);
 	}
-	if (verbose >= 3) lglstats (clone);
-	tmp = clone, clone = 0;
+	if (verbose >= 3) lglstats (lclone);
+	tmp = lclone, lclone = 0;
 #ifndef NDEBUG
 	fres = 
 #endif

--- a/ilingeling.c
+++ b/ilingeling.c
@@ -109,7 +109,7 @@ static signed char * vals;
 static int nlits, szlits;
 static int * lits;
 
-static int verbose, bar, nowitness, plain, clone, deterministic;
+static int verbose, bar, nowitness, plain, lclone, deterministic;
 static int noreverse, addassumptions = 1, noflush, reduce, nomelt;
 
 static const char * druptraceprefix;
@@ -290,13 +290,13 @@ static int sat (Worker * w) {
   int res;
   char name[100];
   LGL * cloned;
-  if (!druptraceprefix && clone) lglsetopt (w->lgl, "clim", CLONELIMIT);
+  if (!druptraceprefix && lclone) lglsetopt (w->lgl, "clim", CLONELIMIT);
   else lglsetopt (w->lgl, "clim", -1),
        lglsetopt (w->lgl, "plim", -1),
        lglsetopt (w->lgl, "dlim", -1);
   if (!noflush) lglflushcache (w->lgl);
   res = lglsat (w->lgl);
-  assert (!druptraceprefix || !clone || res);
+  assert (!druptraceprefix || !lclone || res);
   if (!res && !justreturn (w)) {
     msg (w, 1, "cloning after %d conflicts", CLONELIMIT);
     cloned = lglclone (w->lgl);
@@ -890,7 +890,7 @@ int main (int argc, char ** argv) {
       if (histfilename) die ("two '-t' options");
       if (++i == argc) die ("argument to '-t' missing");
       histfilename = argv[i];
-    } else if (!strcmp (argv[i], "--clone")) clone = 1;
+    } else if (!strcmp (argv[i], "--clone")) lclone = 1;
     else if (!strcmp (argv[i], "--no-flush")) noflush = 1;
     else if (!strcmp (argv[i], "-d") || !strcmp (argv[i], "--drup")) {
       if (++i == argc) die ("argument to '%s' missing", argv[i]);


### PR DESCRIPTION
When compiling on older versions of Linux (e.g., Red Hat Enterprise Linux 5), it has been noticed that there is a compilation conflict between the declarations of the Lingeling variables "clone" and clone(2) that is included in sched.h:

      http://man7.org/linux/man-pages/man2/clone.2.html

This PR suitably renames the Lingeling clone variables to avoid this conflict.