### PR TITLE
correct include for int64_t type

### DIFF
--- a/lglib.h
+++ b/lglib.h
@@ -6,7 +6,7 @@
 #define lglib_h_INCLUDED
 
 #include <stdio.h>				// for 'FILE'
-#include <stdlib.h>				// for 'int64_t'
+#include <stdint.h>				// for 'int64_t'
 
 //--------------------------------------------------------------------------
 


### PR DESCRIPTION
`stdint.h` is the C99-standardized header for fixed-size integers, not `stdlib.h`.
this matters on systems that build against [musl.][musl] other than that, I had no issues building lingeling.

I'm not sure what the scope of target platforms of lingeling is, so I will note that this may break builds on other platforms, [like old versions of MSVC.][missing] it may be preferred to instead detect if this change is necessary in the configure script and/or through the preprocessor.

[musl]: https://www.musl-libc.org/
[missing]: https://stackoverflow.com/questions/126279/c99-stdint-h-header-and-ms-visual-studio